### PR TITLE
copy of Header.js from beacon scroll fix

### DIFF
--- a/src/scripts/components/Header.js
+++ b/src/scripts/components/Header.js
@@ -13,6 +13,7 @@ export default class Header {
     this.config = { ...Header.defaults, ...config };
     this.scrollingDown = null;
     this.scrollingUp = null;
+    this.fixedTopYPos = null;
     this.init();
   }
 
@@ -40,14 +41,54 @@ export default class Header {
   }
 
   onScrollDown = () => {
+    this.fixedTopYPos = null;
+    if(window.innerWidth <= 767)
+    {
+      return;
+    }
     if (!this.scrollingDown) {
       this.element.classList.add(this.config.scrollClass);
+      const headerHeight = 100;
+      const distanceFromTop = Math.abs(
+        document.body.getBoundingClientRect().top
+      );
+      if (distanceFromTop >= headerHeight && document.querySelector('html').offsetHeight - this.element.offsetHeight > window.innerHeight)
+      {
+        this.element.classList.add('fixed-top');
+        this.fixedTopYPos = Math.abs(document.body.getBoundingClientRect().top);
+      }
+      else
+      {
+        this.element.classList.remove('fixed-top');
+      }
       this.scrollingDown = true;
       this.scrollingUp = false;
     }
   };
 
-  onScrollUp = () => {
+  onScrollUp = () => { 
+    if(this.fixedTopYPos != null && this.fixedTopYPos === Math.abs(document.body.getBoundingClientRect().top))
+    {
+      this.fixedTopYPos = null;
+      return;
+    }
+    this.fixedTopYPos = null;
+    if(window.innerWidth <= 767)
+    {
+      return;
+    }
+    const headerHeight = 100;
+    const distanceFromTop = Math.abs(
+      document.body.getBoundingClientRect().top
+    );
+    if (distanceFromTop >= headerHeight && document.querySelector('html').offsetHeight - this.element.offsetHeight > window.innerHeight) 
+    {
+      this.element.classList.add('fixed-top');
+    }
+    else 
+    {
+      this.element.classList.remove('fixed-top');
+    }
     if (!this.scrollingUp) {
       this.element.classList.remove(this.config.scrollClass);
       this.scrollingUp = true;


### PR DESCRIPTION
Not sure if these changes should be pulled into this project or not...

Finished fixing the scroll bug on beacon where if the page size was under a certain level the scroll wouldn't work as the code was stuck in a loop of removing the header shortening the scroll bar, shortened enough to where the current position becomes the bottom of the page and still be pushed up in scroll position, and this triggering a scroll up event. 

This is all tied to the menu toggling whether the header should be position relative or fixed, so when they scroll up the header appears. This logic is handled by the fixed-top class being toggled based on having scrolled over X amount away from the top. This doesn't look to be really used by the existing Header.js in this project though so not sure if this fix is unique to beacon or if it needed to be pulled into AccuTheme as well.